### PR TITLE
Add auth pages

### DIFF
--- a/djangotest/djangotest/settings.py
+++ b/djangotest/djangotest/settings.py
@@ -118,3 +118,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+LOGIN_REDIRECT_URL = '/'

--- a/djangotest/djangotest/settings.py
+++ b/djangotest/djangotest/settings.py
@@ -54,7 +54,7 @@ ROOT_URLCONF = 'djangotest.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/djangotest/djangotest/urls.py
+++ b/djangotest/djangotest/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 urlpatterns = [
+    path('', TemplateView.as_view(template_name = 'home.html')),
     path('admin/', admin.site.urls),
     path('users/', include('django.contrib.auth.urls')),
 ]

--- a/djangotest/djangotest/urls.py
+++ b/djangotest/djangotest/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('users/', include('django.contrib.auth.urls')),
 ]

--- a/djangotest/templates/base.html
+++ b/djangotest/templates/base.html
@@ -10,7 +10,7 @@
 
   <body>
     <div class="ui container">
-      <div class="ui menu">
+      <div class="ui large secondary menu">
         <div class="menu">
           <div class="item">
             <h3>My Wishlist</h3>

--- a/djangotest/templates/base.html
+++ b/djangotest/templates/base.html
@@ -17,7 +17,11 @@
           </div>
         </div>
         <div class="right menu">
-          <a class="item" href="/users/login">Sign-in</a>
+          {% if user.is_authenticated %}
+            <a class="item" href="/users/logout">Sign-out</a>
+          {% else %}
+            <a class="item" href="/users/login">Sign-in</a>
+          {% endif %}
         </div>
       </div>
       {% block content %}{% endblock %}

--- a/djangotest/templates/base.html
+++ b/djangotest/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{% block title %}My Wishlist{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"
+            integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
+  </head>
+
+  <body>
+    <div class="ui container">
+      <div class="ui menu">
+        <div class="menu">
+          <div class="item">
+            <h3>My Wishlist</h3>
+          </div>
+        </div>
+        <div class="right menu">
+          <a class="item" href="/users/login">Sign-in</a>
+        </div>
+      </div>
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/djangotest/templates/home.html
+++ b/djangotest/templates/home.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% endblock %}

--- a/djangotest/templates/registration/login.html
+++ b/djangotest/templates/registration/login.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% if form.errors %}
+  <div class="ui error message">
+  <p>Your username and password didn't match. Please try again.</p>
+  </div>
+{% endif %}
+
+{% if next %}
+  {% if user.is_authenticated %}
+    <p>Your account doesn't have access to this page. To proceed,
+    please login with an account that has access.</p>
+  {% else %}
+    <p>Please login to see this page.</p>
+  {% endif %}
+{% endif %}
+
+<form method="post" action="{% url 'login' %}">
+{% csrf_token %}
+<table>
+
+<tr>
+  <td>{{ form.username.label_tag }}</td>
+  <td>{{ form.username }}</td>
+</tr>
+
+<tr>
+  <td>{{ form.password.label_tag }}</td>
+  <td>{{ form.password }}</td>
+</tr>
+</table>
+
+<input class="ui button" type="submit" value="login" />
+<input type="hidden" name="next" value="{{ next }}" />
+</form>
+
+{# Assumes you setup the password_reset view in your URLconf #}
+<p><a href="{% url 'password_reset' %}">Lost password?</a></p>
+
+{% endblock %}


### PR DESCRIPTION
Mostly based on this tutorial: https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Authentication

This adds:

* Very basic base template (using Semantic UI as a framework).
* An empty home page.
* A menu that has 'Sign-in' and 'Sign-out' links as appropriate.

Work in progress – by default Django reuses the templates for the admin site, which aren't appropriate for the end user. Need to add some more custom templates to replace those.